### PR TITLE
Fix & Enable Word Regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Clear buffer word cache on events (default: `1`)
 let g:asyncomplete_buffer_clear_cache = 1
 ```
 
-Custom regex to dedide how to identify non word characters (defaults: '\W\+')
+Custom regex to dedide how to identify word characters (defaults: '\w\+')
 ```vim
-let g:asyncomplete_buffer_split_regex = get(g:, 'asyncomplete_buffer_split_regex', '\W\+')
+let g:asyncomplete_buffer_identify_words_regex     = '\w\+'
+let g:asyncomplete_buffer_identify_words_regex     = '\k\+' (uses iskeyword)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Clear buffer word cache on events (default: `1`)
 let g:asyncomplete_buffer_clear_cache = 1
 ```
 
+Custom regex to dedide how to identify non word characters (defaults: '\W\+')
+```vim
+let g:asyncomplete_buffer_split_regex = get(g:, 'asyncomplete_buffer_split_regex', '\W\+')
+```
+
+
+
 ### Credits
 All the credit goes to the following projects
 * [https://github.com/roxma/nvim-complete-manager](https://github.com/roxma/nvim-complete-manager)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Clear buffer word cache on events (default: `1`)
 let g:asyncomplete_buffer_clear_cache = 1
 ```
 
-Custom regex to dedide how to identify word characters (defaults: '\w\+')
+Custom regex to dedide how to identify word characters (defaults: `\w\+`)
 ```vim
 let g:asyncomplete_buffer_identify_words_regex     = '\w\+'
 let g:asyncomplete_buffer_identify_words_regex     = '\k\+' (uses iskeyword)

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -60,7 +60,7 @@ function! s:refresh_keywords() abort
         let s:words = {}
     endif
     let l:text = join(getline(1, '$'), "\n")
-    for l:word in map(split(l:text, g:asyncomplete_buffer_identify_words_regex.'\zs'),matchstr(v:val,g:asyncomplete_buffer_identify_words_regex))
+    for l:word in map(split(l:text, g:asyncomplete_buffer_identify_words_regex.'\zs'),'matchstr(v:val,g:asyncomplete_buffer_identify_words_regex)')
         if len(l:word) > 1
             let s:words[l:word] = 1
         endif
@@ -69,7 +69,7 @@ function! s:refresh_keywords() abort
 endfunction
 
 function! s:refresh_keyword_incremental(typed) abort
-    let l:words = map(split(a:typed, g:asyncomplete_buffer_identify_words_regex.'\zs'),matchstr(v:val,g:asyncomplete_buffer_identify_words_regex))
+    let l:words = map(split(a:typed, g:asyncomplete_buffer_identify_words_regex.'\zs'),'matchstr(v:val,g:asyncomplete_buffer_identify_words_regex)')
     for l:word in l:words
         if len(l:word) > 1
             let s:words[l:word] = 1

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -5,9 +5,6 @@ let g:asyncomplete_buffer_identify_words_regex = get(g:, 'asyncomplete_buffer_id
 
 function! asyncomplete#sources#buffer#completor(opt, ctx)
     call asyncomplete#log('asyncomplete#buffer ctx', a:ctx)
-    let l:typed = a:ctx['typed']
-
-    call s:refresh_keyword_incremental(l:typed)
 
     if empty(s:words)
         return
@@ -23,12 +20,12 @@ function! asyncomplete#sources#buffer#completor(opt, ctx)
     let l:matches = map(keys(s:words),'{"word":v:val,"dup":1,"icase":1,"menu": "[buffer]"}')
     let l:startcol = l:col - l:kwlen
 
-    call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches, 1)
+    call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches)
 endfunction
 
 function! asyncomplete#sources#buffer#get_source_options(opts)
     return extend({
-        \ 'events': ['VimEnter', 'BufWinEnter'],
+        \ 'events': ['TextChangedI', 'VimEnter', 'BufWinEnter'],
         \ 'on_event': function('s:on_event'),
         \}, a:opts)
 endfunction
@@ -50,8 +47,13 @@ function! s:should_ignore(opt) abort
 endfunction
 
 function! s:on_event(opt, ctx, event) abort
-    if s:should_ignore(a:opt) | return | endif
-    call s:refresh_keywords()
+    if (a:event ==# 'TextChangedI')
+        let l:typed = a:ctx['typed']
+        call s:refresh_keyword_incremental(l:typed)
+    else
+        if s:should_ignore(a:opt) | return | endif
+        call s:refresh_keywords()
+    endif
 endfunction
 
 function! s:refresh_keywords() abort

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -34,7 +34,7 @@ endfunction
 
 function! asyncomplete#sources#buffer#get_source_options(opts)
     return extend({
-                \ 'events': ['CursorHold','CursorHoldI','BufWinEnter','BufWritePost','TextChangedI'],
+        \ 'events': ['CursorHold','CursorHoldI','BufWinEnter','BufWritePost','TextChangedI'],
         \ 'on_event': function('s:on_event'),
         \}, a:opts)
 endfunction
@@ -53,7 +53,7 @@ function! s:on_event(opt, ctx, event) abort
         endif
     endif
 
-    if a:event == 'TextChangedI'
+    if a:event ==# 'TextChangedI'
         call s:refresh_keyword_incr(a:ctx['typed'])
     else
         if s:last_ctx == a:ctx

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -14,7 +14,7 @@ function! asyncomplete#sources#buffer#completor(opt, ctx)
     let l:col = a:ctx['col']
     let l:typed = a:ctx['typed']
 
-    let l:kw = matchstr(l:typed, '\w\+$')
+    let l:kw = matchstr(l:typed, g:asyncomplete_buffer_identify_words_regex .'$')
     let l:kwlen = len(l:kw)
 
     if l:kwlen < 1
@@ -69,7 +69,7 @@ function! s:refresh_keywords() abort
         let s:words = {}
     endif
     let l:text = join(getline(1, '$'), "\n")
-    for l:word in map(split(l:text, g:asyncomplete_buffer_identify_words_regex.'\zs'),'matchstr(v:val,g:asyncomplete_buffer_identify_words_regex)')
+    for l:word in s:split_words(l:text)
         if len(l:word) > 1
             let s:words[l:word] = 1
         endif
@@ -77,7 +77,7 @@ function! s:refresh_keywords() abort
 endfunction
 
 function! s:refresh_keyword_incr(typed) abort
-    let l:words = split(a:typed, '\W\+')
+    let l:words = s:split_words(a:typed)
     if len(l:words) > 1
         for l:word in l:words[:len(l:words)-2]
                 let s:words[l:word] = 1
@@ -87,4 +87,8 @@ function! s:refresh_keyword_incr(typed) abort
         let l:new_last_word = l:words[len(l:words)-1:][0]
         let s:last_word = l:new_last_word
     endif
+endfunction
+
+function! s:split_words(text)
+    return  map(split(a:text, g:asyncomplete_buffer_identify_words_regex.'\zs'),'matchstr(v:val,g:asyncomplete_buffer_identify_words_regex)')
 endfunction

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -72,8 +72,8 @@ function! s:refresh_keyword_incremental(typed) abort
     let l:words = map(split(a:typed, g:asyncomplete_buffer_identify_words_regex.'\zs'),'matchstr(v:val,g:asyncomplete_buffer_identify_words_regex)')
     call asyncomplete#log('asyncomplete#sources#buffer', 'refreshing words with ', l:words)
     for l:word in l:words
-        if len(l:word) > 1
+        " if len(l:word) > 1
             let s:words[l:word] = 1
-        endif
+        " endif
     endfor
 endfunction

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -1,7 +1,7 @@
 let s:words = {}
 let s:last_word = ''
 let g:asyncomplete_buffer_clear_cache = get(g:, 'asyncomplete_buffer_clear_cache', 1)
-let g:asyncomplete_buffer_identify_non_words_regex = get(g:, 'asyncomplete_buffer_identify_non_workds_regex', '\W\+')
+let g:asyncomplete_buffer_identify_non_words_regex = get(g:, 'asyncomplete_buffer_identify_non_words_regex', '\W\+')
 let g:asyncomplete_buffer_identify_words_regex     = get(g:, 'asyncomplete_buffer_identify_words_regex', '\w\+$')
 
 function! asyncomplete#sources#buffer#completor(opt, ctx)
@@ -60,7 +60,7 @@ function! s:refresh_keywords() abort
         let s:words = {}
     endif
     let l:text = join(getline(1, '$'), "\n")
-    for l:word in split(l:text, g:asyncomplete_buffer_split_regex)
+    for l:word in split(l:text, g:asyncomplete_buffer_identify_non_words_regex)
         if len(l:word) > 1
             let s:words[l:word] = 1
         endif
@@ -69,7 +69,7 @@ function! s:refresh_keywords() abort
 endfunction
 
 function! s:refresh_keyword_incremental(typed) abort
-    let l:words = split(a:typed, g:asyncomplete_buffer_split_regex)
+    let l:words = split(a:typed,g:asyncomplete_buffer_identify_non_words_regex)
     for l:word in l:words
         if len(l:word) > 1
             let s:words[l:word] = 1

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -49,7 +49,6 @@ function! s:should_ignore(opt) abort
     return 0
 endfunction
 
-let s:last_ctx = {}
 function! s:on_event(opt, ctx, event) abort
     if s:should_ignore(a:opt) | return | endif
     call s:refresh_keywords()
@@ -68,13 +67,19 @@ function! s:refresh_keywords() abort
     call asyncomplete#log('asyncomplete#buffer', 's:refresh_keywords() complete')
 endfunction
 
+
+let s:last_typed = ''
 function! s:refresh_keyword_incremental(typed) abort
     call asyncomplete#log('asyncomplete#sources#buffer', 'typed words ', a:typed)
-    let l:words = map(split(a:typed, g:asyncomplete_buffer_identify_words_regex.'\zs'),'matchstr(v:val,g:asyncomplete_buffer_identify_words_regex)')
-    call asyncomplete#log('asyncomplete#sources#buffer', 'refreshing words with ', l:words)
-    for l:word in l:words
-        " if len(l:word) > 1
-            let s:words[l:word] = 1
-        " endif
-    endfor
+    if (len(a:typed) == 1)
+        let l:words = map(split(s:last_typed, g:asyncomplete_buffer_identify_words_regex.'\zs'),'matchstr(v:val,g:asyncomplete_buffer_identify_words_regex)')
+        call asyncomplete#log('asyncomplete#sources#buffer', 'refreshing words with ', l:words)
+        for l:word in l:words
+            if len(l:word) > 1
+                let s:words[l:word] = 1
+            endif
+        endfor
+    else
+        let s:last_typed = a:typed
+    endif
 endfunction

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -67,7 +67,7 @@ function! s:refresh_keywords() abort
 endfunction
 
 function! s:refresh_keyword_incremental(typed) abort
-    let l:words = split(a:typed, '\k\+')
+    let l:words = split(a:typed, '\k\@!')
 
     for l:word in l:words
         if len(l:word) > 1

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -15,7 +15,7 @@ function! asyncomplete#sources#buffer#completor(opt, ctx)
 
     let l:col = a:ctx['col']
 
-    let l:kw = matchstr(l:typed, '\w\+$')
+    let l:kw = matchstr(l:typed, '\k@!\+')
     let l:kwlen = len(l:kw)
 
     let l:matches = map(keys(s:words),'{"word":v:val,"dup":1,"icase":1,"menu": "[buffer]"}')
@@ -58,7 +58,7 @@ function! s:refresh_keywords() abort
         let s:words = {}
     endif
     let l:text = join(getline(1, '$'), "\n")
-    for l:word in split(l:text, '\k\+')
+    for l:word in split(l:text, '\k@!\+')
         if len(l:word) > 1
             let s:words[l:word] = 1
         endif

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -4,6 +4,7 @@ let g:asyncomplete_buffer_clear_cache = get(g:, 'asyncomplete_buffer_clear_cache
 let g:asyncomplete_buffer_identify_words_regex = get(g:, 'asyncomplete_buffer_identify_words_regex', '\w\+')
 
 function! asyncomplete#sources#buffer#completor(opt, ctx)
+    call asyncomplete#log('asyncomplete#buffer ctx', a:ctx)
     let l:typed = a:ctx['typed']
 
     call s:refresh_keyword_incremental(l:typed)

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -1,7 +1,8 @@
 let s:words = {}
 let s:last_word = ''
 let g:asyncomplete_buffer_clear_cache = get(g:, 'asyncomplete_buffer_clear_cache', 1)
-let g:asyncomplete_buffer_split_regex = get(g:, 'asyncomplete_buffer_split_regex', '\W\+')
+let g:asyncomplete_buffer_identify_non_words_regex = get(g:, 'asyncomplete_buffer_identify_non_workds_regex', '\W\+')
+let g:asyncomplete_buffer_identify_words_regex     = get(g:, 'asyncomplete_buffer_identify_words_regex', '\w\+$')
 
 function! asyncomplete#sources#buffer#completor(opt, ctx)
     let l:typed = a:ctx['typed']
@@ -16,7 +17,7 @@ function! asyncomplete#sources#buffer#completor(opt, ctx)
 
     let l:col = a:ctx['col']
 
-    let l:kw = matchstr(l:typed, '\k\@!')
+    let l:kw = matchstr(l:typed, g:asyncomplete_buffer_identify_words_regex)
     let l:kwlen = len(l:kw)
 
     let l:matches = map(keys(s:words),'{"word":v:val,"dup":1,"icase":1,"menu": "[buffer]"}')

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -1,8 +1,7 @@
 let s:words = {}
 let s:last_word = ''
 let g:asyncomplete_buffer_clear_cache = get(g:, 'asyncomplete_buffer_clear_cache', 1)
-let g:asyncomplete_buffer_identify_non_words_regex = get(g:, 'asyncomplete_buffer_identify_non_words_regex', '\W\+')
-let g:asyncomplete_buffer_identify_words_regex     = get(g:, 'asyncomplete_buffer_identify_words_regex', '\w\+')
+let g:asyncomplete_buffer_identify_words_regex = get(g:, 'asyncomplete_buffer_identify_words_regex', '\w\+')
 
 function! asyncomplete#sources#buffer#completor(opt, ctx)
     let l:typed = a:ctx['typed']
@@ -69,7 +68,9 @@ function! s:refresh_keywords() abort
 endfunction
 
 function! s:refresh_keyword_incremental(typed) abort
+    call asyncomplete#log('asyncomplete#sources#buffer', 'typed words ', a:typed)
     let l:words = map(split(a:typed, g:asyncomplete_buffer_identify_words_regex.'\zs'),'matchstr(v:val,g:asyncomplete_buffer_identify_words_regex)')
+    call asyncomplete#log('asyncomplete#sources#buffer', 'refreshing words with ', l:words)
     for l:word in l:words
         if len(l:word) > 1
             let s:words[l:word] = 1

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -14,6 +14,7 @@ function! asyncomplete#sources#buffer#completor(opt, ctx)
 
     let l:col = a:ctx['col']
 
+    let l:typed = a:ctx['typed']
     let l:kw = matchstr(l:typed, g:asyncomplete_buffer_identify_words_regex.'$')
     let l:kwlen = len(l:kw)
 

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -15,7 +15,7 @@ function! asyncomplete#sources#buffer#completor(opt, ctx)
 
     let l:col = a:ctx['col']
 
-    let l:kw = matchstr(l:typed, '\k@!\+')
+    let l:kw = matchstr(l:typed, '\k\@!')
     let l:kwlen = len(l:kw)
 
     let l:matches = map(keys(s:words),'{"word":v:val,"dup":1,"icase":1,"menu": "[buffer]"}')
@@ -58,7 +58,7 @@ function! s:refresh_keywords() abort
         let s:words = {}
     endif
     let l:text = join(getline(1, '$'), "\n")
-    for l:word in split(l:text, '\k@!\+')
+    for l:word in split(l:text, '\k\@!')
         if len(l:word) > 1
             let s:words[l:word] = 1
         endif

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -26,7 +26,7 @@ endfunction
 
 function! asyncomplete#sources#buffer#get_source_options(opts)
     return extend({
-        \ 'events': ['BufWinEnter'],
+        \ 'events': ['VimEnter', 'BufWinEnter'],
         \ 'on_event': function('s:on_event'),
         \}, a:opts)
 endfunction
@@ -50,10 +50,7 @@ endfunction
 let s:last_ctx = {}
 function! s:on_event(opt, ctx, event) abort
     if s:should_ignore(a:opt) | return | endif
-
-    if a:event == 'BufWinEnter'
-        call s:refresh_keywords()
-    endif
+    call s:refresh_keywords()
 endfunction
 
 function! s:refresh_keywords() abort
@@ -61,7 +58,7 @@ function! s:refresh_keywords() abort
         let s:words = {}
     endif
     let l:text = join(getline(1, '$'), "\n")
-    for l:word in split(l:text, '\W\+')
+    for l:word in split(l:text, '\k\+')
         if len(l:word) > 1
             let s:words[l:word] = 1
         endif
@@ -70,7 +67,7 @@ function! s:refresh_keywords() abort
 endfunction
 
 function! s:refresh_keyword_incremental(typed) abort
-    let l:words = split(a:typed, '\W\+')
+    let l:words = split(a:typed, '\k\+')
 
     for l:word in l:words
         if len(l:word) > 1

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -22,7 +22,7 @@ function! asyncomplete#sources#buffer#completor(opt, ctx)
     let l:matches = map(keys(s:words),'{"word":v:val,"dup":1,"icase":1,"menu": "[buffer]"}')
     let l:startcol = l:col - l:kwlen
 
-    call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches)
+    call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches, 1)
 endfunction
 
 function! asyncomplete#sources#buffer#get_source_options(opts)

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -1,6 +1,7 @@
 let s:words = {}
 let s:last_word = ''
 let g:asyncomplete_buffer_clear_cache = get(g:, 'asyncomplete_buffer_clear_cache', 1)
+let g:asyncomplete_buffer_split_regex = get(g:, 'asyncomplete_buffer_split_regex', '\W\+')
 
 function! asyncomplete#sources#buffer#completor(opt, ctx)
     let l:typed = a:ctx['typed']
@@ -58,7 +59,7 @@ function! s:refresh_keywords() abort
         let s:words = {}
     endif
     let l:text = join(getline(1, '$'), "\n")
-    for l:word in split(l:text, '\k\@!')
+    for l:word in split(l:text, g:asyncomplete_buffer_split_regex)
         if len(l:word) > 1
             let s:words[l:word] = 1
         endif
@@ -67,8 +68,7 @@ function! s:refresh_keywords() abort
 endfunction
 
 function! s:refresh_keyword_incremental(typed) abort
-    let l:words = split(a:typed, '\k\@!')
-
+    let l:words = split(a:typed, g:asyncomplete_buffer_split_regex)
     for l:word in l:words
         if len(l:word) > 1
             let s:words[l:word] = 1

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -2,7 +2,7 @@ let s:words = {}
 let s:last_word = ''
 let g:asyncomplete_buffer_clear_cache = get(g:, 'asyncomplete_buffer_clear_cache', 1)
 let g:asyncomplete_buffer_identify_non_words_regex = get(g:, 'asyncomplete_buffer_identify_non_words_regex', '\W\+')
-let g:asyncomplete_buffer_identify_words_regex     = get(g:, 'asyncomplete_buffer_identify_words_regex', '\w\+$')
+let g:asyncomplete_buffer_identify_words_regex     = get(g:, 'asyncomplete_buffer_identify_words_regex', '\w\+')
 
 function! asyncomplete#sources#buffer#completor(opt, ctx)
     let l:typed = a:ctx['typed']
@@ -17,7 +17,7 @@ function! asyncomplete#sources#buffer#completor(opt, ctx)
 
     let l:col = a:ctx['col']
 
-    let l:kw = matchstr(l:typed, g:asyncomplete_buffer_identify_words_regex)
+    let l:kw = matchstr(l:typed, g:asyncomplete_buffer_identify_words_regex.'$')
     let l:kwlen = len(l:kw)
 
     let l:matches = map(keys(s:words),'{"word":v:val,"dup":1,"icase":1,"menu": "[buffer]"}')
@@ -60,7 +60,7 @@ function! s:refresh_keywords() abort
         let s:words = {}
     endif
     let l:text = join(getline(1, '$'), "\n")
-    for l:word in split(l:text, g:asyncomplete_buffer_identify_non_words_regex)
+    for l:word in map(split(l:text, g:asyncomplete_buffer_identify_words_regex.'\zs'),matchstr(v:val,g:asyncomplete_buffer_identify_words_regex))
         if len(l:word) > 1
             let s:words[l:word] = 1
         endif
@@ -69,7 +69,7 @@ function! s:refresh_keywords() abort
 endfunction
 
 function! s:refresh_keyword_incremental(typed) abort
-    let l:words = split(a:typed,g:asyncomplete_buffer_identify_non_words_regex)
+    let l:words = map(split(a:typed, g:asyncomplete_buffer_identify_words_regex.'\zs'),matchstr(v:val,g:asyncomplete_buffer_identify_words_regex))
     for l:word in l:words
         if len(l:word) > 1
             let s:words[l:word] = 1


### PR DESCRIPTION
This fixes the issue of not matching words in the last line

It also introduces a variable to set a regex to identify a word. Particularly useful to set so that this changes across different file types using `iskeyword`

```
let g:asyncomplete_buffer_identify_words_regex     = '\k\+' 
```